### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
         uses: textbook/git-checkout-submodule-action@master
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: syoboi-calendar-grpc-server
           username: chao


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore